### PR TITLE
Do not raise the exception

### DIFF
--- a/cdc/__main__.py
+++ b/cdc/__main__.py
@@ -84,4 +84,3 @@ if __name__ == "__main__":
     except Exception as e:
         logger = logging.getLogger(__name__)
         logger.exception(e)
-        raise e


### PR DESCRIPTION
It seems we are missing prod errors from sentry because we are re-throwing the exception at the end of main.
This should be a quick fix to get all we need for troubleshooting while we figure out whether there is a good way to have the event in sentry and the exception re-thrown