### PR TITLE
Require `enable.idempotence` to be set on the Kafka producer configuration.

### DIFF
--- a/cdc/types.py
+++ b/cdc/types.py
@@ -2,6 +2,10 @@ from datetime import datetime
 from typing import Callable, NamedTuple
 
 
+class ConfigurationError(Exception):
+    pass
+
+
 class ScheduledTask(NamedTuple):
     deadline: datetime
     callable: Callable[[], None]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Click==7.0
 PyYAML==5.1
-confluent-kafka==0.11.6
+confluent-kafka==1.0.0
 datadog==0.21.0
 jsonschema==3.0.1
 psycopg2-binary==2.7.7

--- a/tests/cdc/streams/backends/test_kafka.py
+++ b/tests/cdc/streams/backends/test_kafka.py
@@ -1,0 +1,15 @@
+import pytest
+
+from cdc.streams.backends.kafka import KafkaProducerBackend
+from cdc.types import ConfigurationError
+
+
+def test_idempotence_required():
+    KafkaProducerBackend("topic", {})  # should not raise
+
+    KafkaProducerBackend("topic", {"enable.idempotence": "true"})  # should not raise
+
+    KafkaProducerBackend("topic", {"enable.idempotence": True})  # should not raise
+
+    with pytest.raises(ConfigurationError):
+        KafkaProducerBackend("topic", {"enable.idempotence": "false"})


### PR DESCRIPTION
More details: https://github.com/edenhill/librdkafka/blob/v1.0.0/INTRODUCTION.md#idempotent-producer

We probably should require `enable.gapless.guarantee` as well?