### PR TITLE
Remove the message written metric

### DIFF
--- a/cdc/producer.py
+++ b/cdc/producer.py
@@ -99,7 +99,6 @@ class Producer(object):
                     )
                 else:
                     logger.trace("Succesfully wrote %r to %r.", message, self.producer)
-                    self.__stats.message_written()
                     self.source.set_write_position(message.id, message.position)
                     message = None
 

--- a/cdc/utils/stats.py
+++ b/cdc/utils/stats.py
@@ -15,7 +15,6 @@ METRIC_PREFIX = "cdc"
 
 
 class Stats:
-    MESSAGE_WRITTEN_METRIC = "message_written"
     MESSAGE_FLUSHED_METRIC = "message_flushed"
     TASK_EXECUTED_TIME_METRIC = "task_executed"
 
@@ -47,9 +46,6 @@ class Stats:
         if not self.__task_sampling_rate:
             self.__task_sampling_rate = 1
 
-    def message_written(self) -> None:
-        self.__increment(self.MESSAGE_WRITTEN_METRIC, self.__message_sampling_rate)
-
     def message_flushed(self, start: int) -> None:
         self.__record_simple_interval(
             start, self.MESSAGE_FLUSHED_METRIC, self.__message_sampling_rate
@@ -60,12 +56,6 @@ class Stats:
         self.__record_simple_interval(
             start, self.TASK_EXECUTED_TIME_METRIC, self.__task_sampling_rate, [tag]
         )
-
-    def __increment(self, metric: str, sample_rate: int, tags: list = None) -> None:
-        try:
-            self.__dogstatsd.increment(metric, tags=tags, sample_rate=sample_rate)
-        except Exception as e:
-            logger.exception(e)
 
     def __record_simple_interval(
         self, start: float, metric: str, sample_rate: int, tags: list = None

--- a/tests/cdc/utils/test_stats.py
+++ b/tests/cdc/utils/test_stats.py
@@ -18,10 +18,6 @@ task_sampling_rate: 1
 def test(mock_incr, mock_timing) -> None:
     configuration = yaml.load(CONFIG, Loader=yaml.SafeLoader)
     stats = Stats(configuration)
-    stats.message_written()
-    mock_incr.assert_called_with(
-        Stats.MESSAGE_WRITTEN_METRIC, tags=None, sample_rate=0.1
-    )
 
     stats.message_flushed(10)
     mock_timing.assert_called_with(


### PR DESCRIPTION
Test removing this metric that should in theory be redundant.
The goal here is to see how much we gain in perf by removing it 