### PR TITLE
Make all the dockers nicer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 **/*.pyc
 **/__pycache__
 .git
+.gitignore
 .mypy_cache/
+.travis/
+cloudbuild.yaml
+README.rst
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,59 @@
 FROM python:3.7-slim AS application
 
+RUN groupadd -r cdc && useradd -r -g cdc cdc
+
+# grab gosu for easy step-down from root
+RUN set -x \
+    && export GOSU_VERSION=1.11 \
+    && fetchDeps=" \
+        dirmngr \
+        gnupg \
+        wget \
+    " \
+    && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && for key in \
+      B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    ; do \
+      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    done \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && gpgconf --kill all \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true \
+    && apt-get purge -y --auto-remove $fetchDeps
+
+# grab tini for signal processing and zombie killing
+RUN set -x \
+    && export TINI_VERSION=0.18.0 \
+    && fetchDeps=" \
+        dirmngr \
+        gnupg \
+        wget \
+    " \
+    && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
+    && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini" \
+    && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && for key in \
+      595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+    ; do \
+      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    done \
+    && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+    && gpgconf --kill all \
+    && rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
+    && chmod +x /usr/local/bin/tini \
+    && tini -h \
+    && apt-get purge -y --auto-remove $fetchDeps
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
@@ -7,10 +61,12 @@ COPY requirements.txt /usr/src/app/
 RUN pip install -r requirements.txt
 
 COPY . /usr/src/app
+ENV PATH /usr/src/app/bin:$PATH
 
 RUN pip install -e .
 
-ENTRYPOINT ["python", "-m", "cdc"]
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
+CMD ["cdc"]
 
 FROM application AS development
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec python -m cdc "$@"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
   args: [
             'build',
             '--pull',
+            '--target', 'application',
             '-t', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
             '-t', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
             '--cache-from', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# first check if we're passing flags, if so
+# prepend with cdc
+if [ "${1:0:1}" = '-' ]; then
+    set -- cdc "$@"
+fi
+
+# Check for a valid cdc subcommand
+if cdc "$1" --help > /dev/null 2>&1; then
+    set -- cdc "$@"
+fi
+
+if [ "$1" = 'cdc' -a "$(id -u)" = '0' ]; then
+    set -- gosu cdc tini -- "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The primary changes are:

* Introduce a docker-entrypoint script, which correctly drops permissions, and allows intercepting and say, hopping into bash.
* Introduce gosu for dropping permissions, and tini as a zombie process reaper.
* Only build the application target image, and not the full development one for production.
* Introduce a `bin/cdc` wrapper to more simply differentiate between wanting say, a python REPL vs running `cdc` the application.