### PR TITLE
Make test not fail in teardown

### DIFF
--- a/tests/cdc/sources/backends/test_postgres_logical.py
+++ b/tests/cdc/sources/backends/test_postgres_logical.py
@@ -39,11 +39,17 @@ def dsn():
             yield template.format(database=database_name)
         finally:
             with connection.cursor() as cursor:
-                # Kill all connections to the test database.
-                # This will not delete our current connection cause we are
-                # connected to the "postgres" database.
+                # There could be lingering connections to the database. This can
+                # happen if we are able to establish a connection to the database
+                # but cannot create a replication slot.
+                #
+                # Given that this is a test and we want to delete the test database,
+                # we may first have to kill all connections to the test database.
+                #
+                # The following line will not delete our current connection cause
+                # we are connected to the "postgres" database.
                 cursor.execute(
-                    "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = %s",
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = %s",
                     [database_name]
                 )
 


### PR DESCRIPTION
## Background
`test_postgres_logical.py` creates a test database every time it runs, which gets deleted in teardown. It also expectedly throws an error if it cannot add any more replication slots. This can happen if `max_replication_slots=1` and the replication slot is being used by the dev environment.

## Problem
When it does throw the "cannot add any more replication slots" error, we are still holding a connection to the temporary database. So, in teardown, when we try to drop the database, we get another error:
```
psycopg2.OperationalError: database "cdc_test_6673d912a4cd11e98136acde48001122" is being accessed by other users
DETAIL:  There is 1 other session using the database.
```
And then, we have a test database in postgres that never gets deleted.

## Solution
With this PR, we close off all connections to the temporary test database before dropping the database.