### PR TITLE
fix: SIGTERM to kill cdc

### DIFF
--- a/cdc/__main__.py
+++ b/cdc/__main__.py
@@ -79,6 +79,7 @@ def producer(ctx):
         producer.stop()
 
     signal.signal(signal.SIGINT, handle_interrupt)
+    signal.signal(signal.SIGTERM, handle_interrupt)
     producer.run()
 
 


### PR DESCRIPTION
Kubernetes sends a SIGTERM when shutting down CDC. Today, when we get a SIGTERM, CDC is killed, but not gracefully. This PR makes it die gracefully by trapping the SIGTERM.

SNS-160