### PR TITLE
feat(cdc) Send init/abort messages from cdc on cdc control topic

### DIFF
--- a/cdc/__main__.py
+++ b/cdc/__main__.py
@@ -154,7 +154,10 @@ def snapshot(ctx, snapshot_config):
             snapshot_config["destination"]["type"],
             snapshot_config["destination"]["options"],
         ),
-        SnapshotControl(producer_factory(configuration["snapshot"]["producer"])),
+        SnapshotControl(
+            producer_factory(configuration["snapshot"]["producer"]),
+            configuration["snapshot"]["producer"]["poll_timeout"],
+        ),
         snapshot_config["product"],
         tables_config,
     )

--- a/cdc/__main__.py
+++ b/cdc/__main__.py
@@ -155,7 +155,8 @@ def snapshot(ctx, snapshot_config):
             snapshot_config["destination"]["options"],
         ),
         SnapshotControl(
-            producer_factory(configuration["snapshot"]["producer"]),
+            producer_factory(configuration["snapshot"]["control"]["producer"]),
+            configuration["snapshot"]["control"].get("options"),
         ),
         snapshot_config["product"],
         tables_config,
@@ -184,7 +185,8 @@ def snapshot_abort(ctx, snapshot_id):
         raise Exception("Invalid snapshot configuration file version")
 
     control = SnapshotControl(
-        producer_factory(configuration["snapshot"]["producer"]),
+        producer_factory(configuration["snapshot"]["control"]["producer"]),
+        configuration["snapshot"]["control"].get("options"),
     )
     control.abort_snapshot(UUID(snapshot_id))
     control.wait_messages_sent()

--- a/cdc/__main__.py
+++ b/cdc/__main__.py
@@ -168,11 +168,9 @@ def snapshot(ctx, snapshot_config):
 @main.command(
     help="Aborts a snapshot by sending the message on the control topic"
 )
-@click.option(
-    "-s",
-    "--snapshot-id",
+@click.argument(
+    "snapshot_id",
     type=click.STRING,
-    help="Snapshot ID to stop",
 )
 @click.pass_context
 def snapshot_abort(ctx, snapshot_id):

--- a/cdc/__main__.py
+++ b/cdc/__main__.py
@@ -106,7 +106,7 @@ def snapshot(ctx, snapshot_config):
     from cdc.snapshots.sources import registry as source_registry
     from cdc.snapshots.destinations import registry as destination_registry
     from cdc.snapshots.snapshot_control import SnapshotControl
-    from cdc.streams import producer_factory, PRODUCER_SCHEMA
+    from cdc.streams import producer_factory
     configuration = ctx.obj
     
     snapshot_config = yaml.load(snapshot_config, Loader=yaml.SafeLoader)
@@ -145,11 +145,6 @@ def snapshot(ctx, snapshot_config):
         for t in snapshot_config['tables']
     ]
 
-    jsonschema.validate(
-        configuration["snapshot"]["producer"],
-        PRODUCER_SCHEMA,
-    )
-
     coordinator = SnapshotCoordinator(
         source_registry.new(
             configuration["snapshot"]["source"]["type"],
@@ -161,7 +156,6 @@ def snapshot(ctx, snapshot_config):
         ),
         SnapshotControl(
             producer_factory(configuration["snapshot"]["producer"]),
-            configuration["snapshot"]["producer"].get("flush_timeout"),
         ),
         snapshot_config["product"],
         tables_config,
@@ -183,20 +177,14 @@ def snapshot(ctx, snapshot_config):
 def snapshot_abort(ctx, snapshot_id):
     from uuid import UUID
     from cdc.snapshots.snapshot_control import SnapshotControl
-    from cdc.streams import producer_factory, PRODUCER_SCHEMA
+    from cdc.streams import producer_factory
     configuration = ctx.obj
     
     if configuration["version"] != 1:
         raise Exception("Invalid snapshot configuration file version")
 
-    jsonschema.validate(
-        configuration["snapshot"]["producer"],
-        PRODUCER_SCHEMA,
-    )
-
     control = SnapshotControl(
         producer_factory(configuration["snapshot"]["producer"]),
-        configuration["snapshot"]["producer"].get("flush_timeout"),
     )
     control.abort_snapshot(UUID(snapshot_id))
     control.wait_messages_sent()

--- a/cdc/__main__.py
+++ b/cdc/__main__.py
@@ -105,6 +105,8 @@ def snapshot(ctx, snapshot_config):
     from cdc.snapshots.snapshot_coordinator import SnapshotCoordinator
     from cdc.snapshots.sources import registry as source_registry
     from cdc.snapshots.destinations import registry as destination_registry
+    from cdc.snapshots.snapshot_control import SnapshotControl
+    from cdc.streams import producer_factory
     configuration = ctx.obj
     
     snapshot_config = yaml.load(snapshot_config, Loader=yaml.SafeLoader)
@@ -152,11 +154,39 @@ def snapshot(ctx, snapshot_config):
             snapshot_config["destination"]["type"],
             snapshot_config["destination"]["options"],
         ),
+        SnapshotControl(producer_factory(configuration["snapshot"]["producer"])),
         snapshot_config["product"],
         tables_config,
     )
 
     coordinator.start_process()
+
+
+@main.command(
+    help="Aborts a snapshot by sending the message on the control topic"
+)
+@click.option(
+    "-s",
+    "--snapshot-id",
+    type=click.STRING,
+    help="Snapshot ID to stop",
+)
+@click.pass_context
+def snapshot_abort(ctx, snapshot_id):
+    from uuid import UUID
+    from cdc.snapshots.snapshot_control import SnapshotControl
+    from cdc.streams import producer_factory
+    configuration = ctx.obj
+    
+    if configuration["version"] != 1:
+        raise Exception("Invalid snapshot configuration file version")
+
+    control = SnapshotControl(
+        producer_factory(configuration["snapshot"]["producer"]),
+        configuration["snapshot"]["producer"]["poll_timeout"],
+    )
+    control.abort_snapshot(UUID(snapshot_id))
+    control.wait_messages_sent()
 
 
 if __name__ == "__main__":

--- a/cdc/configuration.yaml
+++ b/cdc/configuration.yaml
@@ -19,10 +19,10 @@ source:
     backend:
         type: postgres_logical
         options:
-            dsn: 'postgres://postgres@sentry_postgres:5432/sentry'
+            dsn: 'postgres://postgres@sentry_postgres:5432/pgbench'
             slot:
-                name: 'cdc'
-                plugin: 'wal2json'
+                name: 'pgbench'
+                plugin: 'test_decoding'
                 create: true
                 options:
                     include-xids: 'true'
@@ -45,12 +45,12 @@ producer:
     backend:
         type: kafka
         options:
-            topic: cdc
+            topic: topic
             options:
                 bootstrap.servers: 'sentry_kafka:9093'
 
 dogstatsd:
-    host: host.docker.internal
+    host: localhost
     port: 8125
     message_sampling_rate: 0.1
     task_sampling_rate: 1.0

--- a/cdc/configuration.yaml
+++ b/cdc/configuration.yaml
@@ -30,6 +30,14 @@ snapshot:
         type: postgres
         options:
             dsn: 'postgres://postgres@sentry_postgres:5432/pgbench'
+    producer:
+        poll_timeout: 10
+        backend:
+            type: kafka
+            options:
+                topic: control_topic
+                options:
+                    bootstrap.servers: 'sentry_kafka:9093'
 
 producer:
     backend:

--- a/cdc/configuration.yaml
+++ b/cdc/configuration.yaml
@@ -19,11 +19,14 @@ source:
     backend:
         type: postgres_logical
         options:
-            dsn: 'postgres://postgres@sentry_postgres:5432/pgbench'
+            dsn: 'postgres://postgres@sentry_postgres:5432/sentry'
             slot:
-                name: 'pgbench'
-                plugin: 'test_decoding'
+                name: 'cdc'
+                plugin: 'wal2json'
                 create: true
+                options:
+                    include-xids: 'true'
+                    include-timestamp: 'true'
 
 snapshot:
     source:
@@ -31,7 +34,6 @@ snapshot:
         options:
             dsn: 'postgres://postgres@sentry_postgres:5432/pgbench'
     producer:
-        poll_timeout: 10
         backend:
             type: kafka
             options:
@@ -43,12 +45,12 @@ producer:
     backend:
         type: kafka
         options:
-            topic: topic
+            topic: cdc
             options:
                 bootstrap.servers: 'sentry_kafka:9093'
 
 dogstatsd:
-    host: localhost
+    host: host.docker.internal
     port: 8125
     message_sampling_rate: 0.1
     task_sampling_rate: 1.0

--- a/cdc/configuration.yaml
+++ b/cdc/configuration.yaml
@@ -33,13 +33,14 @@ snapshot:
         type: postgres
         options:
             dsn: 'postgres://postgres@sentry_postgres:5432/pgbench'
-    producer:
-        backend:
-            type: kafka
-            options:
-                topic: control_topic
+    control:
+        producer:
+            backend:
+                type: kafka
                 options:
-                    bootstrap.servers: 'sentry_kafka:9093'
+                    topic: cdc_control
+                    options:
+                        bootstrap.servers: 'sentry_kafka:9093'
 
 producer:
     backend:

--- a/cdc/snapshots/control_protocol.py
+++ b/cdc/snapshots/control_protocol.py
@@ -15,7 +15,7 @@ class ControlMessage(ABC):
 
 
 @dataclass(frozen=True)
-class SnapshotInit:
+class SnapshotInit(ControlMessage):
     snapshot_id: SnapshotId
     product: str
 
@@ -27,7 +27,7 @@ class SnapshotInit:
         }
 
 @dataclass(frozen=True)
-class SnapshotAbort:
+class SnapshotAbort(ControlMessage):
     snapshot_id: SnapshotId
 
     def serialize(self) -> Mapping[str, Any]:
@@ -37,7 +37,7 @@ class SnapshotAbort:
         }
 
 @dataclass(frozen=True)
-class SnapshotLoaded:
+class SnapshotLoaded(ControlMessage):
     snapshot_id: SnapshotId
     datasets: Mapping[str, Mapping[str, Any]]
     transaction_info: SnapshotDescriptor

--- a/cdc/snapshots/control_protocol.py
+++ b/cdc/snapshots/control_protocol.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, asdict
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from cdc.snapshots.snapshot_types import (
     Xid,
@@ -10,7 +10,7 @@ from cdc.snapshots.snapshot_types import (
 
 class ControlMessage(ABC):
     @abstractmethod
-    def serialize(self) -> Mapping[str, Any]:
+    def to_dict(self) -> Mapping[str, Any]:
         raise NotImplementedError
 
 
@@ -18,10 +18,12 @@ class ControlMessage(ABC):
 class SnapshotInit(ControlMessage):
     snapshot_id: SnapshotId
     product: str
+    tables: Sequence[str]
 
-    def serialize(self) -> Mapping[str, Any]:
+    def to_dict(self) -> Mapping[str, Any]:
         return {
             "event": "snapshot-init",
+            "tables": self.tables,
             "snapshot-id": self.snapshot_id,
             "product": self.product
         }
@@ -30,7 +32,7 @@ class SnapshotInit(ControlMessage):
 class SnapshotAbort(ControlMessage):
     snapshot_id: SnapshotId
 
-    def serialize(self) -> Mapping[str, Any]:
+    def to_dict(self) -> Mapping[str, Any]:
         return {
             "event": "snapshot-abort",
             "snapshot-id": self.snapshot_id,
@@ -39,13 +41,11 @@ class SnapshotAbort(ControlMessage):
 @dataclass(frozen=True)
 class SnapshotLoaded(ControlMessage):
     snapshot_id: SnapshotId
-    datasets: Mapping[str, Mapping[str, Any]]
     transaction_info: SnapshotDescriptor
 
-    def serialize(self) -> Mapping[str, Any]:
+    def to_dict(self) -> Mapping[str, Any]:
         return {
             "event": "snapshot-loaded",
             "snapshot-id": self.snapshot_id,
-            "datasets": self.datasets,
             "transaction-info": asdict(self.transaction_info),
         }

--- a/cdc/snapshots/control_protocol.py
+++ b/cdc/snapshots/control_protocol.py
@@ -1,0 +1,51 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, asdict
+from typing import Any, Mapping
+
+from cdc.snapshots.snapshot_types import (
+    Xid,
+    SnapshotId,
+    SnapshotDescriptor
+)
+
+class ControlMessage(ABC):
+    @abstractmethod
+    def serialize(self) -> Mapping[str, Any]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class SnapshotInit:
+    snapshot_id: SnapshotId
+    product: str
+
+    def serialize(self) -> Mapping[str, Any]:
+        return {
+            "event": "snapshot-init",
+            "snapshot-id": self.snapshot_id,
+            "product": self.product
+        }
+
+@dataclass(frozen=True)
+class SnapshotAbort:
+    snapshot_id: SnapshotId
+
+    def serialize(self) -> Mapping[str, Any]:
+        return {
+            "event": "snapshot-abort",
+            "snapshot-id": self.snapshot_id,
+        }
+
+@dataclass(frozen=True)
+class SnapshotLoaded:
+    snapshot_id: SnapshotId
+    datasets: Mapping[str, Mapping[str, Any]]
+    transaction_info: SnapshotDescriptor
+
+    def serialize(self) -> Mapping[str, Any]:
+        return {
+            "event": "snapshot-loaded",
+            "snapshot-id": self.snapshot_id,
+            "datasets": self.datasets,
+            "transaction-info": asdict(self.transaction_info),
+        }

--- a/cdc/snapshots/snapshot_control.py
+++ b/cdc/snapshots/snapshot_control.py
@@ -10,13 +10,16 @@ from cdc.snapshots.control_protocol import (
     SnapshotInit,
 )
 from cdc.snapshots.snapshot_types import SnapshotId, TableConfig
-from cdc.sources.types import Message
+from cdc.sources.types import Message, Payload
 from cdc.streams import Producer as StreamProducer
 from cdc.utils.logging import LoggerAdapter
 
 logger = LoggerAdapter(logging.getLogger(__name__))
 
 class SnapshotControl:
+    """
+    Sends messages on the CDC control topic.
+    """
 
     def __init__(
         self,
@@ -35,10 +38,10 @@ class SnapshotControl:
             msg,
         )
 
-
     def __write_msg(self, message: ControlMessage) -> None:
+        json_string = json.dumps(message.serialize())
         self.__producer.write(
-            payload=json.dumps(message.serialize()),
+            payload=Payload(json_string.encode()),
             callback=partial(self.__msg_sent, message)
         )
 

--- a/cdc/snapshots/snapshot_control.py
+++ b/cdc/snapshots/snapshot_control.py
@@ -2,7 +2,7 @@ import json # type: ignore
 import logging
 
 from functools import partial
-from typing import Sequence
+from typing import Optional, Sequence
 from uuid import UUID
 
 from cdc.snapshots.control_protocol import (
@@ -28,13 +28,13 @@ class SnapshotControl:
     def __init__(
         self,
         producer: StreamProducer,
-        poll_timeout: int,
+        flush_timeout: Optional[int],
     ) -> None:
         self.__producer = producer
-        self.__poll_timeout = poll_timeout
+        self.__flush_timeout = flush_timeout or 10
 
     def wait_messages_sent(self) -> None:
-        messages_in_queue = self.__producer.flush(self.__poll_timeout)
+        messages_in_queue = self.__producer.flush(self.__flush_timeout)
         if messages_in_queue > 0:
             raise ProducerQueueNotEmpty(
                 f"The producer queue is not empty after flush timed out. "

--- a/cdc/snapshots/snapshot_control.py
+++ b/cdc/snapshots/snapshot_control.py
@@ -28,13 +28,11 @@ class SnapshotControl:
     def __init__(
         self,
         producer: StreamProducer,
-        flush_timeout: Optional[int],
     ) -> None:
         self.__producer = producer
-        self.__flush_timeout = flush_timeout or 10
 
     def wait_messages_sent(self) -> None:
-        messages_in_queue = self.__producer.flush(self.__flush_timeout)
+        messages_in_queue = self.__producer.flush()
         if messages_in_queue > 0:
             raise ProducerQueueNotEmpty(
                 f"The producer queue is not empty after flush timed out. "

--- a/cdc/snapshots/snapshot_control.py
+++ b/cdc/snapshots/snapshot_control.py
@@ -38,7 +38,7 @@ class SnapshotControl:
         if messages_in_queue > 0:
             raise ProducerQueueNotEmpty(
                 f"The producer queue is not empty after flush timed out. "
-                "{messages_in_queue} messages still in queue." 
+                f"Messages still in queue: {messages_in_queue}" 
             )
 
 

--- a/cdc/snapshots/snapshot_control.py
+++ b/cdc/snapshots/snapshot_control.py
@@ -1,0 +1,56 @@
+import json # type: ignore
+import logging
+
+from functools import partial
+from uuid import UUID
+
+from cdc.snapshots.control_protocol import (
+    ControlMessage,
+    SnapshotAbort,
+    SnapshotInit,
+)
+from cdc.snapshots.snapshot_types import SnapshotId, TableConfig
+from cdc.sources.types import Message
+from cdc.streams import Producer as StreamProducer
+from cdc.utils.logging import LoggerAdapter
+
+logger = LoggerAdapter(logging.getLogger(__name__))
+
+class SnapshotControl:
+
+    def __init__(
+        self,
+        producer: StreamProducer,
+        poll_timeout: int,
+    ) -> None:
+        self.__producer = producer
+        self.__poll_timeout = poll_timeout
+
+    def wait_messages_sent(self) -> None:
+        self.__producer.poll(self.__poll_timeout)
+
+    def __msg_sent(self, msg: ControlMessage) -> None:
+        logger.debug(
+            "Message sent %r",
+            msg,
+        )
+
+
+    def __write_msg(self, message: ControlMessage) -> None:
+        self.__producer.write(
+            payload=json.dumps(message.serialize()),
+            callback=partial(self.__msg_sent, message)
+        )
+
+    def init_snapshot(self, snapshot_id: UUID, product: str) -> None:
+        init_message = SnapshotInit(
+            snapshot_id=SnapshotId(str(snapshot_id)),
+            product=product,
+        )
+        self.__write_msg(init_message)
+
+    def abort_snapshot(self, snapshot_id: UUID) -> None:
+        abort_message = SnapshotAbort(
+            snapshot_id=SnapshotId(str(snapshot_id)),
+        )
+        self.__write_msg(abort_message)

--- a/cdc/snapshots/snapshot_control.py
+++ b/cdc/snapshots/snapshot_control.py
@@ -2,6 +2,7 @@ import json # type: ignore
 import logging
 
 from functools import partial
+from typing import Sequence
 from uuid import UUID
 
 from cdc.snapshots.control_protocol import (
@@ -39,14 +40,19 @@ class SnapshotControl:
         )
 
     def __write_msg(self, message: ControlMessage) -> None:
-        json_string = json.dumps(message.serialize())
+        json_string = json.dumps(message.to_dict())
         self.__producer.write(
-            payload=Payload(json_string.encode()),
+            payload=Payload(json_string.encode("utf-8")),
             callback=partial(self.__msg_sent, message)
         )
 
-    def init_snapshot(self, snapshot_id: UUID, product: str) -> None:
+    def init_snapshot(self,
+        snapshot_id: UUID,
+        tables: Sequence[str],
+        product: str,
+    ) -> None:
         init_message = SnapshotInit(
+            tables=tables,
             snapshot_id=SnapshotId(str(snapshot_id)),
             product=product,
         )

--- a/cdc/snapshots/snapshot_coordinator.py
+++ b/cdc/snapshots/snapshot_coordinator.py
@@ -5,9 +5,9 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import Any, AnyStr, IO, Mapping, Sequence
 
-from cdc.snapshots.snapshot_control import SnapshotControl
 from cdc.snapshots.destinations import DestinationContext
 from cdc.snapshots.sources import SnapshotSource
+from cdc.snapshots.snapshot_control import SnapshotControl
 from cdc.snapshots.snapshot_types import SnapshotId, TableConfig
 from cdc.streams import Producer as StreamProducer
 from cdc.utils.logging import LoggerAdapter
@@ -43,8 +43,10 @@ class SnapshotCoordinator(ABC):
         logger.debug("Starting snapshot process for product %s", self.__product)
         snapshot_id = uuid.uuid1()
         logger.info("Starting snapshot ID %s", snapshot_id)
+        table_names = [t.table for t in self.__tables]
         self.__control.init_snapshot(
             snapshot_id=snapshot_id,
+            tables=table_names,
             product=self.__product,
         )
         with self.__destination.open(

--- a/cdc/streams/__init__.py
+++ b/cdc/streams/__init__.py
@@ -46,7 +46,7 @@ class Producer(object):
         """
         self.__backend.poll(timeout)
 
-    def flush(self, timeout: Optional[float]=None) -> int:
+    def flush(self, timeout: float) -> int:
         """
         Wait for all messages to be flushed or the timeout to be reached,
         whichever comes first.

--- a/cdc/streams/__init__.py
+++ b/cdc/streams/__init__.py
@@ -1,5 +1,5 @@
 import jsonschema  # type: ignore
-from typing import Callable
+from typing import Callable, Optional
 
 from cdc.sources.types import Payload
 from cdc.streams.backends import ProducerBackend, producer_registry
@@ -46,7 +46,7 @@ class Producer(object):
         """
         self.__backend.poll(timeout)
 
-    def flush(self, timeout: float) -> int:
+    def flush(self, timeout: Optional[float]=None) -> int:
         """
         Wait for all messages to be flushed or the timeout to be reached,
         whichever comes first.
@@ -55,28 +55,23 @@ class Producer(object):
         return self.__backend.flush(timeout)
 
 
-PRODUCER_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "flush_timeout": {
-            "type": "integer",
-        },
-        "backend": {
-            "type": "object",
-            "properties": {
-                "type": {"type": "string"},
-                "options": {"type": "object"},
-            },
-            "required": ["type"],
-        }
-    },
-    "required": ["backend"],
-}
-
 def producer_factory(configuration: Configuration) -> Producer:
     jsonschema.validate(
         configuration,
-        PRODUCER_SCHEMA,
+        {
+            "type": "object",
+            "properties": {
+                "backend": {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string"},
+                        "options": {"type": "object"},
+                    },
+                    "required": ["type"],
+                }
+            },
+            "required": ["backend"],
+        },
     )
     return Producer(
         backend=producer_registry.new(

--- a/cdc/streams/__init__.py
+++ b/cdc/streams/__init__.py
@@ -50,27 +50,33 @@ class Producer(object):
         """
         Wait for all messages to be flushed or the timeout to be reached,
         whichever comes first.
+        Returns the number of messages still in queue, thus not sent.
         """
         return self.__backend.flush(timeout)
 
 
+PRODUCER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "flush_timeout": {
+            "type": "integer",
+        },
+        "backend": {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string"},
+                "options": {"type": "object"},
+            },
+            "required": ["type"],
+        }
+    },
+    "required": ["backend"],
+}
+
 def producer_factory(configuration: Configuration) -> Producer:
     jsonschema.validate(
         configuration,
-        {
-            "type": "object",
-            "properties": {
-                "backend": {
-                    "type": "object",
-                    "properties": {
-                        "type": {"type": "string"},
-                        "options": {"type": "object"},
-                    },
-                    "required": ["type"],
-                }
-            },
-            "required": ["backend"],
-        },
+        PRODUCER_SCHEMA,
     )
     return Producer(
         backend=producer_registry.new(

--- a/cdc/streams/__init__.py
+++ b/cdc/streams/__init__.py
@@ -46,12 +46,12 @@ class Producer(object):
         """
         self.__backend.poll(timeout)
 
-    def flush(self, timeout: float) -> None:
+    def flush(self, timeout: float) -> int:
         """
         Wait for all messages to be flushed or the timeout to be reached,
         whichever comes first.
         """
-        self.__backend.flush(timeout)
+        return self.__backend.flush(timeout)
 
 
 def producer_factory(configuration: Configuration) -> Producer:

--- a/cdc/streams/backends/__init__.py
+++ b/cdc/streams/backends/__init__.py
@@ -30,7 +30,7 @@ class ProducerBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def flush(self, timeout: Optional[float]=None) -> int:
+    def flush(self, timeout: float) -> int:
         raise NotImplementedError
 
 

--- a/cdc/streams/backends/__init__.py
+++ b/cdc/streams/backends/__init__.py
@@ -30,7 +30,7 @@ class ProducerBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def flush(self, timeout: float) -> None:
+    def flush(self, timeout: float) -> int:
         raise NotImplementedError
 
 

--- a/cdc/streams/backends/__init__.py
+++ b/cdc/streams/backends/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Callable
+from typing import Callable, Optional
 
 from cdc.sources.types import Payload
 from cdc.utils.logging import LoggerAdapter
@@ -30,7 +30,7 @@ class ProducerBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def flush(self, timeout: float) -> int:
+    def flush(self, timeout: Optional[float]=None) -> int:
         raise NotImplementedError
 
 

--- a/cdc/streams/backends/kafka.py
+++ b/cdc/streams/backends/kafka.py
@@ -20,11 +20,9 @@ class KafkaProducerBackend(ProducerBackend):
 
     def __init__(self,
         topic: str,
-        flush_timeout: Optional[float],
         options: Mapping[str, Any],
     ):
         self.__topic = topic
-        self.__flush_timeout = flush_timeout or 10
         self.__producer = Producer(options)
 
     def __repr__(self) -> str:
@@ -56,8 +54,8 @@ class KafkaProducerBackend(ProducerBackend):
     def poll(self, timeout: float) -> None:
         self.__producer.poll(timeout)
 
-    def flush(self, timeout: Optional[float]=None) -> int:
-        return self.__producer.flush(timeout or self.__flush_timeout)
+    def flush(self, timeout: float) -> int:
+        return self.__producer.flush(timeout)
 
 
 def kafka_producer_backend_factory(
@@ -69,7 +67,6 @@ def kafka_producer_backend_factory(
             "type": "object",
             "properties": {
                 "topic": {"type": "string"},
-                "flush_timeout": {"type": "number"},
                 "options": {"type": "object", "properties": {}},  # TODO
             },
             "required": ["topic"],
@@ -77,6 +74,5 @@ def kafka_producer_backend_factory(
     )
     return KafkaProducerBackend(
         topic=configuration["topic"],
-        flush_timeout=configuration.get("flush_timeout"),
         options=configuration["options"],
     )

--- a/cdc/streams/backends/kafka.py
+++ b/cdc/streams/backends/kafka.py
@@ -51,8 +51,8 @@ class KafkaProducerBackend(ProducerBackend):
     def poll(self, timeout: float) -> None:
         self.__producer.poll(timeout)
 
-    def flush(self, timeout: float) -> None:
-        self.__producer.flush(timeout)
+    def flush(self, timeout: float) -> int:
+        return self.__producer.flush(timeout)
 
 
 def kafka_producer_backend_factory(

--- a/tests/cdc/snapshots/test_control.py
+++ b/tests/cdc/snapshots/test_control.py
@@ -1,0 +1,39 @@
+import json # type: ignore
+import uuid
+
+from typing import Callable, List
+
+from cdc.snapshots.control_protocol import (
+    SnapshotAbort,
+    SnapshotInit,
+)
+from cdc.sources.types import Message, Payload
+from cdc.streams import Producer as StreamProducer
+from cdc.snapshots.snapshot_control import SnapshotControl
+
+class DummyProducer(StreamProducer):
+    def __init__(self) -> None:
+        self.items: List[bytes] = []
+
+    def write(self, payload: Payload, callback: Callable[[], None]) -> None:
+        self.items.append(payload)
+        callback()
+
+    def poll(self, timeout: float) -> None:
+        pass
+
+class TestSnapshotControl:
+    def test_init(self) -> None:
+        uuid = uuid.uuid1()
+        producer = DummyProducer()
+        control = SnapshotControl(producer, 0)
+        control.init_snapshot(
+            snapshot_id=uuid,
+            product="snuba"
+        )
+
+        reloaded = json.loads(producer.items[0])
+        assert reloaded == {
+            "snapshot_id": str(uuid),
+            "product": "snuba"
+        }

--- a/tests/cdc/snapshots/test_control.py
+++ b/tests/cdc/snapshots/test_control.py
@@ -1,5 +1,5 @@
 import json # type: ignore
-import uuid
+from uuid import uuid1
 
 from typing import Callable, List
 
@@ -24,7 +24,7 @@ class DummyProducer(StreamProducer):
 
 class TestSnapshotControl:
     def test_init(self) -> None:
-        uuid = uuid.uuid1()
+        uuid = uuid1()
         producer = DummyProducer()
         control = SnapshotControl(producer, 0)
         control.init_snapshot(
@@ -34,6 +34,7 @@ class TestSnapshotControl:
 
         reloaded = json.loads(producer.items[0])
         assert reloaded == {
-            "snapshot_id": str(uuid),
-            "product": "snuba"
+            "snapshot-id": str(uuid),
+            "product": "snuba",
+            "event": "snapshot-init"
         }

--- a/tests/cdc/snapshots/test_control.py
+++ b/tests/cdc/snapshots/test_control.py
@@ -26,7 +26,7 @@ class TestSnapshotControl:
     def test_init(self) -> None:
         uuid = uuid1()
         producer = DummyProducer()
-        control = SnapshotControl(producer, 0)
+        control = SnapshotControl(producer, {})
         control.init_snapshot(
             snapshot_id=uuid,
             tables=["my_table"],

--- a/tests/cdc/snapshots/test_control.py
+++ b/tests/cdc/snapshots/test_control.py
@@ -29,6 +29,7 @@ class TestSnapshotControl:
         control = SnapshotControl(producer, 0)
         control.init_snapshot(
             snapshot_id=uuid,
+            tables=["my_table"],
             product="snuba"
         )
 
@@ -36,5 +37,6 @@ class TestSnapshotControl:
         assert reloaded == {
             "snapshot-id": str(uuid),
             "product": "snuba",
+            "tables": ["my_table"],
             "event": "snapshot-init"
         }


### PR DESCRIPTION
The cdc side of the snapshot is supposed to send three messages on the cdc_control topic to communicate with the consumer.
snapshot-init, snapshot-abort, snapshot-loaded

This makes the snapshot taking script send the snapshot-init. It also adds a script to send the abort and cancel everything.