### PR TITLE
freight: Remove the kubernetes block

### DIFF
--- a/.freight.yaml
+++ b/.freight.yaml
@@ -4,13 +4,6 @@
 #   project: cdc
 #   repository: getsentry/cdc
 
-kubernetes:
-  credentials:
-    kind: gcloud
-    project: internal-sentry
-    cluster: primary
-    zone: us-central1-b
-
 steps:
 - kind: KubernetesDeployment
   selector:


### PR DESCRIPTION
This has been moved into freight config since it's not very useful here