### PR TITLE
Upgrade to python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info/
 *.pyc
 .mypy_cache/
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim AS application
+FROM python:3.8-slim AS application
 
 RUN groupadd -r cdc && useradd -r -g cdc cdc
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==19.3b0
 mock==3.0.5
-mypy==0.670
+mypy==0.800
 pyflakes==2.1.1
-pytest==4.5.0
+pytest==5.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click==7.0
 PyYAML==5.1
-confluent-kafka==0.11.6
+confluent-kafka==1.5.0
 datadog==0.21.0
 jsonschema==3.0.1
-psycopg2-binary==2.7.7
+psycopg2-binary==2.8.6
 sentry-sdk==0.7.14


### PR DESCRIPTION
Upgrade the docker image to python 3.8. This requires an upgrade of psycopg and the kafka client (upgraded to the same version we have on snuba). 