### PR TITLE
feat(releasing): Add release script to CDC

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: "0.20.0"
+minVersion: "0.21.1"
 
 github:
   owner: getsentry
@@ -8,8 +8,6 @@ changelogPolicy: none
 
 artifactProvider:
   name: none
-statusProvider:
-  name: github
 
 preReleaseCommand: ''
 

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,26 @@
+minVersion: "0.20.0"
+
+github:
+  owner: getsentry
+  repo: cdc
+# TODO: Add a changelog
+changelogPolicy: none
+
+artifactProvider:
+  name: none
+statusProvider:
+  name: github
+
+preReleaseCommand: ''
+
+targets:
+  - name: github
+  - id: release
+    name: docker
+    source: us.gcr.io/sentryio/cdc
+    target: getsentry/cdc
+  - id: latest
+    name: docker
+    source: us.gcr.io/sentryio/cdc
+    target: getsentry/cdc
+    targetFormat: '{{{target}}}:latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: 'Release a new version'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
We will have to cut releases. 

This now does not follow calver, but that is up for debate. CDC is not a core part of sentry, more of an external dependency (it is also not BSL @BYK  what do you think? ). 