### PR TITLE
feat(freight) Deploy the cdc image from the public repo

### DIFF
--- a/.freight.yaml
+++ b/.freight.yaml
@@ -9,5 +9,5 @@ steps:
   selector:
     label_selector: service=cdc
   containers:
-  - image: us.gcr.io/internal-sentry/github_getsentry_cdc:{sha}
+  - image: us.gcr.io/sentryio/cdc:{sha}
     name: producer


### PR DESCRIPTION
We do not need to deploy the image from sentry internal anymore as there is a working image on `us.gcr.io/sentryio/`

@JTCunning I believe this should be enough to switch the deployment process to the public image. Is that correct ?